### PR TITLE
Publish fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,5 +41,5 @@ jobs:
           draft: false
           prerelease: false
           name: ${{ steps.vars.outputs.version }}
-          git_tag: ${{ steps.vars.outputs.version }}
+          tag_name: ${{ steps.vars.outputs.version }}
           generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
         "dev": "NODE_ENV=development rollup --config ./rollup.config.js",
         "prod": "NODE_ENV=production rollup --config ./rollup.config.js",
         "watch": "npm run dev -- --watch",
-        "prepare": "npm run prod",
         "test": "NODE_ENV=testing jest --config ./jest.config.js",
         "lint": "eslint . --config ./.eslintrc.js"
     },


### PR DESCRIPTION
* Removes `prepare` as we explicitly run `yarn run prod` during package creation
* https://github.com/softprops/action-gh-release had wrong key for automatic tag creation